### PR TITLE
Global Injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,18 +154,20 @@ Those functions use currently used global scope, coming from either `registerGlo
 **❗While in functions it might be desired to use currently used scope, behaviour of global injectors in class instance methods might result in unpredictable behaviour!**
 
 ## Global class injection
-Preferable way to inject services into classes is by using `Injected` mixin. It overwrites global injection methods with the same signature as functional equivalents, but with consistent scope sampled from the time of class creation.
+Preferable way to inject services into classes is by using `Injected` mixin. It provides methods with the same signature as functional equivalents, but with consistent scope sampled from the time of class creation.
+
+**To use those methods, prefixing them with `this` is necessary!**
 
 ```dart
 class Example with Injected {
-    late final DepA _dependency = injectRequired<DepA>();
+    late final DepA _dependency = this.injectRequired<DepA>();
 
     printFromField(){
         debugPrint(_dependency.message);
     }
 
     printFromInjection(){
-        debugPrint(injectRequired<DepA>().message)
+        debugPrint(this.injectRequired<DepA>().message)
     }
 }
 
@@ -208,7 +210,7 @@ Dispose.of(getCurrentScope().createScope())
 
 // Using mixin flow
 class A with Scoped {
-    late final DepA _dependencyA = provideInScope((scope) => scope.provideRequired<DepA>());
+    final DepA _dependencyA = provideInScope((scope) => scope.provideRequired<DepA>());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Those functions use currently used global scope, coming from either `registerGlo
 **❗While in functions it might be desired to use currently used scope, behaviour of global injectors in class instance methods might result in unpredictable behaviour!**
 
 ## Global class injection
-Preferable way to inject services into classes is by using `Injected` mixin. It does injection methods with the same signature as functional equivalend, but with consistent scope sampled from the time of class creation.
+Preferable way to inject services into classes is by using `Injected` mixin. It overwrites global injection methods with the same signature as functional equivalents, but with consistent scope sampled from the time of class creation.
 
 ```dart
 class Example with Injected {

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # Summary
 A simple Dependency Injection framework implementation based on `T.hashCode`. It is a simple port of the most basic functionalities of a .NET default dependency container.
 
-Implemented:
-- Service registration
-- Service providing
-- Singleton service handling
-- Transient service handling
-- Scoping (special case of singleton services with lifetime of a container or it's scoped copy)
-- Unit tests [♟️]
-- **Mostly** automatic cleaning after containers and their services
-
-Not implemented:
-- Registering services with functional destructors [♟️]
-- Source generation [👾]
-- Circular reference prevention [😐]
-- Keyed services [😐]
-- Decorator based injection [💀]
-- Automatic constructor invocation [💀]
-- Automatic decorator based registration [💀]
-- Multiple implementations of singular type [💀]
+Planned functionalities:
+- [x] Service registration
+- [x] Service providing
+- [x] Singleton service handling
+- [x] Transient service handling
+- [x] Scoping (special case of singleton services with lifetime of a container or it's scoped copy)
+- [x] Unit tests
+- [x] **Mostly** automatic cleaning after containers and their services
+- [x] Global injectors
+- [ ] Registering services with functional destructors [♟️]
+- [ ] Source generation [👾]
+- [ ] Circular reference prevention [😐]
+- [ ] Keyed services [😐]
+- [ ] Decorator based injection [💀]
+- [ ] Automatic constructor invocation [💀]
+- [ ] Automatic decorator based registration [💀]
+- [ ] Multiple implementations of singular type [💀]
 
 Legend:
 - ♟️ - most likely to be implemented
@@ -30,12 +29,18 @@ Legend:
 
 **❗This project mostly serves as a way for me to learn and play around with Dart language and Flutter framework.❗**
 
-**❗ While it does work and serves it's purpose relatively well, it was not tested properly and might contain bugs or performance issues. (especially with isolates)❗**
+**❗ While it does work and serves it's purpose relatively well, it was not testing was surface level at best and might contain bugs or performance issues. (especially with isolates)❗**
 
 ## Creating a container 
 Services can be added by chaining methods `ServiceContainerBuilder.add<T>(T Function(ServiceContainer) builder, lifetime: ServiceLifeTime.singleton)`. 
 
-Lifetime can be one of: `[singleton, scoped, transient]`.
+Lifetimes are described in table below:
+| Lifetime  | Behaviour                                                      |
+| --------- | -------------------------------------------------------------- |
+| singleton | Single instance for entire lifetime of a container             |
+| transient | Instance created on each injection                             |
+| scoped    | Instance created on each scoped during first injection from it |
+
 ```dart
 final builder = new ServiceContainerBuilder()
     .add((container) => {
@@ -65,7 +70,7 @@ ServiceType? nullableService = container.provide<ServiceType>();
 ServiceType service = container.provideRequired<ServiceType>();
 ```
 
-## Automatic cleanup
+# Automatic cleanup
 Dependency Injection introduces easy access to any dependant object needed at the moment, but it also makes it much harder to trace the moment the same objects go out of scope.
 
 For all services that requires cleanup after usage there is implemented a [Disposable pattern](https://en.wikipedia.org/wiki/Dispose_pattern) in form of:
@@ -78,7 +83,7 @@ When registered service implements it, service container will perform automatic 
 
 **While automatic cleanup is optional, it's ill advised to skip it in case any of a services requires cleanup.**
 
-### Cleanup rules:
+## Cleanup rules:
 - Root provider will not cleanup any transient services by itself. It's up to programmer to clean them up.*
 - Scoped containers only cleans their scoped services and transients created within their scope and will ignore their child scopes.
 - Cleanup is not ordered and each `Disposable` should only clean their state without dependant services.
@@ -86,7 +91,7 @@ When registered service implements it, service container will perform automatic 
 
 | * - Since root container can be a long lived object, leaving it to container would cause a lot of trash being piled up without any clearing by either container or garbage collector.
 
-### Quick dispose
+## Quick dispose
 In case a disposable or a scope are supposed to last only to the end of a function or specific part of code, there is an extension available, to help with cleanup:
 ```dart
 final ResultType res = Dispose.of(service)
@@ -101,7 +106,7 @@ final ResultType res = await Dispose.of(service)
         return await resultFuture;
     });
 ```
-## Scoping
+# Scoping
 Scope is an Unit of Work object that holds a copy of scoped service factories.
 
 New scope of a container can be created by invoking `ServiceContainer.createScope()`.
@@ -131,7 +136,91 @@ Each scoped container holds a reference to the root container in case a singleto
 
 While it is possible to create a scoped container from manually created descriptor map, replaced registrations are not reflected in scoped container if specified type was already provided at least once.
 
-## Good practices
+# Global injection
+This library allows for global injection if certain conditions are met:
+- Build container was registered with function `registerGlobalContainer(ServiceContainer container)`
+- Classes implement either `Scoped` or `Injected` mixins
+
+## Global functional injection
+To inject services into functions you can use following methods:
+
+| Global injector function | Container equivalent     | Description                                                |
+| ------------------------ | ------------------------ | ---------------------------------------------------------- |
+| `T? inject<T>()`         | `T? provide<T>()`        | Provides an optional service                               |
+| `T injectRequired<T>()`  | `T provideRequired<T>()` | Provides a required service (will throw if not registered) |
+
+Those functions use currently used global scope, coming from either `registerGlobalContainer(ServiceContainer container)` or `Scoped.provideInScope()`. 
+
+**❗While in functions it might be desired to use currently used scope, behaviour of global injectors in class instance methods might result in unpredictable behaviour!**
+
+## Global class injection
+Preferable way to inject services into classes is by using `Injected` mixin. It does injection methods with the same signature as functional equivalend, but with consistent scope sampled from the time of class creation.
+
+```dart
+class Example with Injected {
+    late final DepA _dependency = injectRequired<DepA>();
+
+    printFromField(){
+        debugPrint(_dependency.message);
+    }
+
+    printFromInjection(){
+        debugPrint(injectRequired<DepA>().message)
+    }
+}
+
+class DepA {
+    static int _sharedCounter = 0;
+    int _counter;
+    DepA(){
+        _counter = _sharedCounter++;
+    }
+    
+    get message(){
+        return "Hello world $_counter";
+    }
+}
+
+// ... Container creation
+
+debugPrint(injectRequired<DepA>().message)  // Hello world 1
+
+final instance = Example();
+instance.printFromField()                  // Hello world 1
+instance.printFromInjection()              // Hello world 1
+
+registerGlobalContainer(getCurrentScope().createScope());
+
+debugPrint(injectRequired<DepA>().message)  // Hello world 2
+instance.printFromField()                  // Hello world 1
+instance.printFromInjection()              // Hello world 1
+```
+
+## Global scoping
+Scoping with global registration can be performed by either creating a scope manually from base container or by using `Scoped` mixin.
+
+```dart
+// Using standard flow
+Dispose.of(getCurrentScope().createScope())
+    .whileAlive(scope => {
+        // ...
+    });
+
+// Using mixin flow
+class A with Scoped {
+    late final DepA _dependencyA = provideInScope((scope) => scope.provideRequired<DepA>());
+}
+```
+
+`provideInScope<T>(T Function(ServiceContainer))` makes sure that all dependant services are coming from the same scope
+as the one constructed for class `A`. Similarly, when other `Scoped` classes are being constructed in nested scenario, `provideInScope()` will make sure to keep scopes consistent.
+
+`Scoped` implements `Disposable` that will dispose of scope at the moment of calling `dispose()` on class itself.
+
+# Usage notes
 - Never work on root provider
 - Don't dispose provided services by yourself
 - Always dispose scopes after work on them is finished
+- Actions resulting in unpredicted behaviours:
+  - Using functional global injectors within class methods (if it's not `Injected`)
+  - Using functional global injectors without `provideInScope()` in `Scoped` class

--- a/lib/src/errors/global_container_not_registered.dart
+++ b/lib/src/errors/global_container_not_registered.dart
@@ -1,0 +1,8 @@
+class GlobalContainerNotRegistered implements Exception {
+  @override
+  String toString() {
+    return ("No global container registered. "
+        "To use this functionality "
+        "use registerGlobalContainer(container)");
+  }
+}

--- a/lib/src/global_injector.dart
+++ b/lib/src/global_injector.dart
@@ -34,18 +34,17 @@ mixin Injected {
 }
 
 mixin Scoped implements Disposable {
-  late final ServiceContainer? _currentScope;
+  final ServiceContainer _currentScope = getCurrentScope().createScope();
 
   @override
   void dispose() {
-    _currentScope?.dispose();
+    _currentScope.dispose();
   }
 
   T provideInScope<T>(T Function(ServiceContainer) injector) {
     final previousScope = getCurrentScope();
-    _currentScope ??= previousScope.createScope();
 
-    registerGlobalContainer(_currentScope!);
+    registerGlobalContainer(_currentScope);
     final result = injector.call(_currentScope);
     registerGlobalContainer(previousScope);
 

--- a/lib/src/global_injector.dart
+++ b/lib/src/global_injector.dart
@@ -1,0 +1,54 @@
+import 'package:simple_di/simple_di.dart';
+import 'package:simple_di/src/errors/global_container_not_registered.dart';
+
+ServiceContainer? _scope;
+
+/// Registers passed container for use by [ScopeInjected] and [Injected] mixins
+void registerGlobalContainer(ServiceContainer container) {
+  _scope = container;
+}
+
+T? inject<T>() {
+  return getCurrentScope().provide<T>();
+}
+
+T injectRequired<T>() {
+  return getCurrentScope().provideRequired<T>();
+}
+
+ServiceContainer getCurrentScope() {
+  if (_scope == null) throw GlobalContainerNotRegistered();
+  return _scope as ServiceContainer;
+}
+
+mixin Injected {
+  final ServiceContainer _currentScope = getCurrentScope();
+
+  T? inject<T>() {
+    return _currentScope.provide<T>();
+  }
+
+  T injectRequired<T>() {
+    return _currentScope.provideRequired<T>();
+  }
+}
+
+mixin Scoped implements Disposable {
+  late final ServiceContainer? _currentScope;
+
+  @override
+  void dispose() {
+    _currentScope?.dispose();
+  }
+
+  T provideInScope<T>(T Function(ServiceContainer) injector) {
+    final previousScope = getCurrentScope();
+    _currentScope ??= previousScope.createScope();
+
+    registerGlobalContainer(_currentScope!);
+    final result = injector.call(_currentScope);
+    registerGlobalContainer(previousScope);
+
+    return result;
+  }
+}

--- a/lib/src/global_injector.dart
+++ b/lib/src/global_injector.dart
@@ -4,7 +4,7 @@ import 'package:simple_di/src/errors/global_container_not_registered.dart';
 ServiceContainer? _scope;
 
 /// Registers passed container for use by [ScopeInjected] and [Injected] mixins
-void registerGlobalContainer(ServiceContainer container) {
+void registerGlobalContainer(ServiceContainer? container) {
   _scope = container;
 }
 

--- a/test/global_injector_test.dart
+++ b/test/global_injector_test.dart
@@ -1,0 +1,154 @@
+import 'package:simple_di/simple_di.dart';
+import 'package:simple_di/src/errors/global_container_not_registered.dart';
+import 'package:simple_di/src/global_injector.dart';
+import 'package:test/test.dart';
+
+// ignore: constant_identifier_names
+var EXPECTED_INTEGER = 4;
+
+typedef DescriptionBuilder = String Function(String description);
+
+void main() {
+  group('Global Functional Injectors', () {
+    test(("inject<T>() throws when scope == null"), () {
+      registerGlobalContainer(null);
+      try {
+        inject<int>();
+      } on Exception catch (ex) {
+        expect(ex.runtimeType, GlobalContainerNotRegistered);
+      }
+    });
+    test(("injectRequired<T>() throws when scope == null"), () {
+      registerGlobalContainer(null);
+      try {
+        inject<int>();
+      } on Exception catch (ex) {
+        expect(ex.runtimeType, GlobalContainerNotRegistered);
+      }
+    });
+  });
+
+  test("[Injected] fails to construct when global scope is null", () {
+    bool thrown = false;
+    try {
+      DependencyMock();
+    } on GlobalContainerNotRegistered {
+      thrown = true;
+    }
+
+    expect(thrown, true);
+  });
+
+  runTests(true, globalFunctionalInjectorsTests);
+  runTests(false, globalFunctionalInjectorsTests);
+  runTests(true, injectedTests);
+  runTests(false, injectedTests);
+}
+
+void runTests(bool scoped, void Function(DescriptionBuilder) testsRunner) {
+  desc(String description) => "(${scoped ? "Scoped" : "Root"}) $description";
+  testsRunner.call(desc);
+}
+
+class DependencyMock with Injected {
+  final int _value = injectRequired<int>();
+
+  resultFromConstructedDependency() => buildResult(_value);
+
+  resultFromInjectedDependency() => buildResult(this.injectRequired<int>());
+
+  static buildResult(int expectedValue) => "Hello world $expectedValue";
+}
+
+globalFunctionalInjectorsTests(DescriptionBuilder desc) {
+  group(desc("Global Functional Injectors"), () {
+    setUp(() {
+      final container =
+          ServiceContainerBuilder().add((sp) => EXPECTED_INTEGER).build();
+      registerGlobalContainer(container);
+    });
+
+    tearDown(() {
+      registerGlobalContainer(null);
+    });
+
+    test(desc("inject<T>() injected service"), () {
+      expect(inject<int>(), EXPECTED_INTEGER);
+    });
+
+    test(desc("injectRequired<T>() injected service"), () {
+      expect(injectRequired<int>(), EXPECTED_INTEGER);
+    });
+
+    test(desc("inject<T>() returns null if service was not registered"), () {
+      expect(inject<String>(), null);
+    });
+
+    test(
+        desc("injectRequired<T>() should throw ServiceNotRegistered"
+            "when service was not registered"), () {
+      try {
+        injectRequired<String>();
+      } on Exception catch (ex) {
+        expect(ex.runtimeType, ServiceNotRegistered);
+      }
+    });
+  });
+}
+
+injectedTests(DescriptionBuilder desc) {
+  buildCurrentlyExpected() => DependencyMock.buildResult(injectRequired<int>());
+  group("Injected tests", () {
+    setUp(() {
+      var value = 0;
+      final container = ServiceContainerBuilder()
+          .add((p0) => value++, lifetime: ServiceLifetime.scoped)
+          .build();
+
+      registerGlobalContainer(container);
+    });
+
+    tearDown(() => registerGlobalContainer(null));
+
+    test(
+        desc("[Injected] provides during construction sucessfully "
+            "within same scope"), () {
+      final expected = buildCurrentlyExpected();
+
+      expect(DependencyMock().resultFromConstructedDependency(), expected);
+    });
+
+    test(
+        desc("[Injected] provides during method injection sucessfully "
+            "within same scope"), () {
+      final expected = buildCurrentlyExpected();
+
+      expect(DependencyMock().resultFromInjectedDependency(), expected);
+    });
+    test(
+        desc("[Injected] provides during construction sucessfully "
+            "and retains previous scope"
+            "when global scope changes"), () {
+      final instance = DependencyMock();
+      final expected = buildCurrentlyExpected();
+
+      registerGlobalContainer(getCurrentScope().createScope());
+      expect(expected == buildCurrentlyExpected(), false);
+
+      expect(instance.resultFromConstructedDependency(), expected);
+    });
+
+    test(
+        desc("[Injected] provides during method injection sucessfully "
+            "and retains previous scope "
+            "when global scope changes"), () {
+      final instance = DependencyMock();
+      final expected = buildCurrentlyExpected();
+
+      registerGlobalContainer(getCurrentScope().createScope());
+      expect(expected == buildCurrentlyExpected(), false);
+
+      expect(instance.resultFromInjectedDependency(), expected);
+    });
+  });
+}

--- a/test/global_injector_test.dart
+++ b/test/global_injector_test.dart
@@ -1,14 +1,38 @@
+import 'package:mockito/mockito.dart';
 import 'package:simple_di/simple_di.dart';
 import 'package:simple_di/src/errors/global_container_not_registered.dart';
 import 'package:simple_di/src/global_injector.dart';
 import 'package:test/test.dart';
 
-// ignore: constant_identifier_names
+import 'common/disposable_mock.dart';
+
+// ignore: constant_identifier_names, non_constant_identifier_names
 var EXPECTED_INTEGER = 4;
 
 typedef DescriptionBuilder = String Function(String description);
 
 void main() {
+  test("[Scoped] disposes scope successfully", () {
+    var disposeCalls = 0;
+    final subject = DisposableMock();
+    when(subject.dispose()).thenAnswer((invocation) {
+      disposeCalls++;
+    });
+
+    registerGlobalContainer(ServiceContainerBuilder()
+        .add((p0) => subject, lifetime: ServiceLifetime.scoped)
+        .add((p0) => 4)
+        .build()
+        .createScope());
+
+    final scoped = ScopedMock();
+    scoped.scope.provide<DisposableMock>();
+    scoped.dispose();
+
+    expect(disposeCalls, 1);
+
+    registerGlobalContainer(null);
+  });
   group('Global Functional Injectors', () {
     test(("inject<T>() throws when scope == null"), () {
       registerGlobalContainer(null);
@@ -43,21 +67,13 @@ void main() {
   runTests(false, globalFunctionalInjectorsTests);
   runTests(true, injectedTests);
   runTests(false, injectedTests);
+  runTests(true, scopedTests);
+  runTests(false, scopedTests);
 }
 
 void runTests(bool scoped, void Function(DescriptionBuilder) testsRunner) {
   desc(String description) => "(${scoped ? "Scoped" : "Root"}) $description";
   testsRunner.call(desc);
-}
-
-class DependencyMock with Injected {
-  final int _value = injectRequired<int>();
-
-  resultFromConstructedDependency() => buildResult(_value);
-
-  resultFromInjectedDependency() => buildResult(this.injectRequired<int>());
-
-  static buildResult(int expectedValue) => "Hello world $expectedValue";
 }
 
 globalFunctionalInjectorsTests(DescriptionBuilder desc) {
@@ -98,7 +114,7 @@ globalFunctionalInjectorsTests(DescriptionBuilder desc) {
 
 injectedTests(DescriptionBuilder desc) {
   buildCurrentlyExpected() => DependencyMock.buildResult(injectRequired<int>());
-  group("Injected tests", () {
+  group("Injected", () {
     setUp(() {
       var value = 0;
       final container = ServiceContainerBuilder()
@@ -151,4 +167,70 @@ injectedTests(DescriptionBuilder desc) {
       expect(instance.resultFromInjectedDependency(), expected);
     });
   });
+}
+
+scopedTests(DescriptionBuilder desc) {
+  buildCurrentlyExpected() =>
+      DependencyMock.buildResult(injectRequired<int>() + 1);
+  group("Scoped", () {
+    setUp(() {
+      final container = ServiceContainerBuilder()
+          .add((sp) => EXPECTED_INTEGER++, lifetime: ServiceLifetime.scoped)
+          .build();
+      registerGlobalContainer(container);
+    });
+
+    tearDown(() {
+      registerGlobalContainer(null);
+    });
+
+    test(
+        desc(
+            "[Scoped] constructed message from provideInScope() shows expected value"),
+        () {
+      final expected = buildCurrentlyExpected();
+      expect(ScopedMock().resultFromConstructedDependency(), expected);
+    });
+    test(
+        desc(
+            "[Scoped] injected message from provideInScope() shows expected value"),
+        () {
+      final currentExpectedInteger = EXPECTED_INTEGER;
+      final expected = buildCurrentlyExpected();
+      final scoped = ScopedMock();
+      expect(scoped.resultFromInjectedDependency(), expected);
+
+      // new scope
+      registerGlobalContainer(getCurrentScope().createScope());
+      expect(inject<int>(), currentExpectedInteger + 2);
+      expect(scoped.resultFromInjectedDependency(), expected);
+    });
+  });
+}
+
+class DependencyMock with Injected {
+  final int _value = injectRequired<int>();
+
+  resultFromConstructedDependency() => buildResult(_value);
+  resultFromInjectedDependency() => buildResult(this.injectRequired<int>());
+
+  static buildResult(int expectedValue) => "Hello world $expectedValue";
+}
+
+class ScopedMock with Scoped {
+  late String _value;
+
+  ServiceContainer get scope => provideInScope((scope) => scope);
+  ScopedMock() {
+    _value = _buildScopedResult();
+  }
+
+  resultFromConstructedDependency() => _value;
+
+  resultFromInjectedDependency() => _buildScopedResult();
+
+  _buildScopedResult() =>
+      provideInScope((scope) => buildResult(scope.provideRequired<int>()));
+
+  static buildResult(int expectedValue) => "Hello world $expectedValue";
 }


### PR DESCRIPTION
- adds support for global injection via functions: 
  - `inject<T>()`
  - `injectRequired<T>()`
- adds support for global injections into classes via:
  - `Scoped` mixin
  - `Injected` mixin
- adds function for registering global container: `registerGlobalContainer(ServiceContainer)`
- adds function for retrieving global container: `ServiceContainer getCurrentScope()`
- updated README.md